### PR TITLE
Oauth

### DIFF
--- a/src/splashed/core_alpha.clj
+++ b/src/splashed/core_alpha.clj
@@ -53,7 +53,6 @@
 (defn token
   [payload options]
   (req! {:method :post
-         :base-url "https://unsplash.com/"
          :path "oauth/token"
          :options options
          :content-type :json

--- a/src/splashed/core_alpha.clj
+++ b/src/splashed/core_alpha.clj
@@ -11,15 +11,13 @@
 ;; Request fns
 
 (defn with-authentication
-  [bearer skip-auth options request]
-  (if skip-auth
-    request
-    (merge-with into request {:headers {"Authorization"
-                                        (if bearer
-                                          (str "Bearer " bearer)
-                                          (->> options
-                                               :access-key
-                                               (str "Client-ID ")))}})))
+  [bearer options request]
+  (merge-with into request {:headers {"Authorization"
+                                      (if bearer
+                                        (str "Bearer " bearer)
+                                        (->> options
+                                             :access-key
+                                             (str "Client-ID ")))}}))
 
 (defn parse-resp
   [{:keys [headers status body]}]
@@ -33,7 +31,7 @@
     {:query-params (cske/transform-keys
                      csk/->snake_case_keyword
                      params)}
-    (with-authentication bearer skip-auth options)
+    (with-authentication bearer options)
     (client/get (str (or base-url default-url) path))
     parse-resp))
 
@@ -45,7 +43,7 @@
                  body)
                json/write-str)
      :content-type :json}
-    (with-authentication bearer skip-auth options)
+    (with-authentication bearer options)
     (client/post (str (or base-url default-url) path))
     parse-resp))
 
@@ -63,8 +61,7 @@
                 :client-secret (:client-secret options)
                 :redirect-uri (:redirect-uri options)
                 :code auth-code
-                :grant-type "authorization_code"}
-         :skip-auth false}))
+                :grant-type "authorization_code"}}))
 
 ;; Users
 (defn- users

--- a/src/splashed/core_alpha.clj
+++ b/src/splashed/core_alpha.clj
@@ -36,13 +36,13 @@
     parse-resp))
 
 (defmethod req! :post
-  [{:keys [path base-url body skip-auth bearer options]}]
+  [{:keys [path base-url body content-type bearer options]}]
   (->>
     {:body (-> (cske/transform-keys
                  csk/->snake_case_keyword
                  body)
                json/write-str)
-     :content-type :json}
+     :content-type content-type}
     (with-authentication bearer options)
     (client/post (str (or base-url default-url) path))
     parse-resp))

--- a/src/splashed/core_alpha.clj
+++ b/src/splashed/core_alpha.clj
@@ -51,17 +51,13 @@
 
 ;; Oauth - authenticate a unsplash user
 (defn token
-  [auth-code options]
+  [payload options]
   (req! {:method :post
          :base-url "https://unsplash.com/"
          :path "oauth/token"
          :options options
          :content-type :json
-         :body {:client-id (:client-id options)
-                :client-secret (:client-secret options)
-                :redirect-uri (:redirect-uri options)
-                :code auth-code
-                :grant-type "authorization_code"}}))
+         :body payload}))
 
 ;; Users
 (defn- users


### PR DESCRIPTION
`with-authentication` can be used to inject a Bearer token (token from a user) or a Client-ID token (token from an application)

`token` can be used to retrive a Bearer token from a user.

Usage example:
```
(token {:client-id "SAME AS ACCESS-KEY"
        :client-secret "SECRET"
        :code "CODE"
        :redirect-uri "urn:ietf:wg:oauth:2.0:oob" 
        :grant-type "authorization_code"}
       {:access-key ACCESS-KEY"})
=>
{:access_token "TOKEN",
 :token_type "Bearer",
 :refresh_token "REFRESH-TOKEN",
 :scope "public",
 :created_at 1570893662}
```

This is the second part of the flow, it assumes that the user has been redirected to the authorization page and we received the `code`. It can be tested by creating a demo application in Unsplash and clicking on `authorize`.

![image](https://user-images.githubusercontent.com/7062224/66703669-5e97ff00-eceb-11e9-838f-a16575013921.png)

This is open the authorization page that can be confirmed to retrieve the `code`:

![image](https://user-images.githubusercontent.com/7062224/66703678-78d1dd00-eceb-11e9-898d-24edb67efa83.png)

With this code we can use this `token` function to retrieve the bearer token from the user. With the bearer token we can call the endpoints that require it.

We may think about implementing a demo frontend application with the whole flow.
